### PR TITLE
Bouncer from strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,97 @@
-# theroadbunch/bouncer [![Build Status](https://scrutinizer-ci.com/g/The-Road-Bunch/bouncer/badges/build.png?b=main)](https://scrutinizer-ci.com/g/The-Road-Bunch/bouncer/build-status/main)
-Bouncer is an easy-to-use allow/deny list interface.  
-In this library is the interface and some usable classes to inject into your services.
-  
+# 📋 Bouncer
 [![Latest Stable Version](https://img.shields.io/packagist/v/theroadbunch/bouncer.svg)](https://packagist.org/packages/theroadbunch/bouncer)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Build Status](https://scrutinizer-ci.com/g/The-Road-Bunch/bouncer/badges/build.png?b=main)](https://scrutinizer-ci.com/g/The-Road-Bunch/bouncer/build-status/main)
+
+_What is Bouncer?_  
+Bouncer is an easy-to-use allow/deny list interface. (currently only handles strings)
+
+_Why the name Bouncer?_  
+In the real-world, a bouncer holds the list of who is allowed entry and who is not.
+
+AllowBouncer: At an exclusive club, the bouncer has a list and if you're not on it, you can't come in.  
+DenyBouncer: The local bar allows almost everyone in, the bouncer has a list of trouble-makers to stop at the door.
 
 ### Contents
-1. [Installation](#installation)  
-2. [Usage](#usage)  
-    a. [Basic Usage](#basic-usage)  
-3. [License](LICENSE)  
+1. [Installation](#install)
+2. [Implementation](#Implementation)  
+   1. [Standard Usage](#standard-usage)  
+   2. [Real-World Use-Case](#example-of-a-real-world-use-case)  
+3. [Bouncers](#bouncers)  
+4. [Abstract Bouncer](#abstract-bouncer)  
+5. [License](LICENSE)  
 
-### <a name="installation">Install using composer</a> <sup><small>[[?]](https://getcomposer.org)</a></small></sup>
+<a name="install"></a>
+### Install using composer</a> <sup><small>[[?]](https://getcomposer.org)</small></sup>
 
 `composer require theroadbunch/bouncer`
 
-<a name="usage"></a>
-### <a name="basic-usage">Basic Usage</a>
+### Implementation
 
-Use `RoadBunch\Bouncer\BouncerFactory` to create your bouncer.  
-All bouncers implement `RoadBunch\Bouncer\BouncerInterface`
+#### Standard Usage
+
+Use `Bouncer::allow()` or `Bouncer::deny()` to create your allow/deny lists (bouncer).
 
 ```php
-use RoadBunch\Bouncer\BouncerFactory;
-use RoadBunch\Bouncer\Rule;
+use RoadBunch\Bouncer\Bouncer;
 
-$subject = 'deniedAndAllowed';
-$subjectList = [$subject];
+$subjectList = ['example', 'one', 'two', 'three'];
+$bouncer = Bouncer::allow($subjectList);
+$bouncer->isAllowed('example'); // true
 
-$bouncer = BouncerFactory::create(Rule::ALLOW, $subjectList);
+$bouncer = Bouncer::deny($subjectList);
+$bouncer->isAllowed('example'); // false
+
+// or
+$subjectList = 'example;one;two;three';
+$bouncer = Bouncer::allow($subjectList);
+$bouncer->isAllowed('one'); // true
+$bouncer->isAllowed('not in list'); // false
+
+$bouncer = Bouncer::deny($subjectList);
+$bouncer->isAllowed('two'); // false
+$bouncer->isAllowed('not in list'); // true
+
+// or 
+$subject = 'onlydomainiwanttosendemailto.com';
+$bouncer = Bouncer::allow($subject);
 $bouncer->isAllowed($subject); // true
-
-$bouncer = BouncerFactory::create(Rule::DENY, $subjectList);
-$bouncer->isAllowed($subject) // false
+$bouncer->isAllowed('example.com'); //false
 ```
 
 Update the Bouncer in real time
-
 ```php
-use RoadBunch\Bouncer\BouncerFactory;
-use RoadBunch\Bouncer\Rule;
+use RoadBunch\Bouncer\Bouncer;
 
 $subject = 'allowedAndThenDenied';
-$subjectList = [$subject];
 
-$bouncer = BouncerFactory::create(Rule::ALLOW, $subjectList);
+$bouncer = Bouncer::allow($subject);
 $bouncer->isAllowed($subject); // true
 
 $bouncer->deny($subject);
 $bouncer->isAllowed($subject); // false
 ```
 
-Example of a real-world use-case
+Using `BouncerFactory::create()`  
+<sub>_This has been deprecated and will be removed from the documentation in version **2.4**_</sub>
+```php
+use RoadBunch\Bouncer\Rule;
+use RoadBunch\Bouncer\BouncerFactory;
+
+$subjectList = ['example', 'one', 'two', 'three'];
+$bouncer = BouncerFactory::create(Rule::ALLOW, $subjectList);
+$bouncer->isAllowed('example'); // true
+$bouncer->isAllowed('not in list'); // false
+```
+
+#### Example of a real-world use-case
 
 ```php
 <?php
+declare(strict_types=1);
 
 use Psr\Log\LoggerInterface;
-use RoadBunch\Bouncer\Rule;
-use RoadBunch\Bouncer\BouncerFactory;
+use RoadBunch\Bouncer\Bouncer;
 use RoadBunch\Bouncer\BouncerInterface;
 
 class Mailer
@@ -73,33 +106,62 @@ class Mailer
     {
         if (!$this->bouncer->isAllowed($address)) {
             $this->logger->warning("Cannot send email to blocked email address: {$address}");
-            return;                       
+            return;
         }
         // do work
         if (/* work fails */) {
             // deny this address in the next run
             $this->bouncer->deny($address);
-            $this->logger->error("Sending failed, {$address} add to block list.")
+            $this->logger->error("Sending failed, {$address} added to block list.")
+            return;
         }
+        $this->logger->info("Sending email to {$address}.");                               
     }
 }
 
-// with deny list
-
-$bouncer = BouncerFactory::create(Rule::DENY, ['someone@example.com']);
+// Create a bouncer that has a DenyList
+$bouncer = Bouncer::deny(['someone@example.com', 'someone_else@example.com']);
 $mailer = new Mailer($bouncer);
 
 $mailer->send('someone@example.com', 'Welcome!'); // logs warning
 $mailer->send('someotheraddress@example.com', 'Welcome!'); // sends mail
-
-// with allowed list
-
-$bouncer = BouncerFactory::create(Rule::ALLOW, ['someone@example.com']);
-$mailer = new Mailer($bouncer);
-
-$mailer->send('someone@example.com', 'Welcome!'); // sends email
-$mailer->send('someotheraddress@example.com', 'Welcome!'); // logs warning
 ```
+
+### Bouncers
+All bouncers implement `RoadBunch\Bouncer\BouncerInterface`
+
+`RoadBunch\Bouncer\BouncerInterface`
+
+| method                     | description                                            | return type |
+|----------------------------|--------------------------------------------------------|-------------|
+| isAllowed(string $subject) | Is this string on the allow list/not on the deny list? | bool        |
+| allow(string $subject)     | Add this string to the allow list                      | void        |
+| deny(string $subject)      | Add this string to the deny list                       | void        |
+
+`RoadBunch\Bouncer\AllowBouncer`
+
+| method                     | description                                        | return type |
+|----------------------------|----------------------------------------------------|-------------|
+| isAllowed(string $subject) | returns `true` if the subject is on the allow list | bool        |
+| allow(string $subject)     | Add this subject to the allow list                 | void        |
+| deny(string $subject)      | Remove this subject from the allow list            | void        |
+
+`RoadBunch\Bouncer\DenyBouncer`
+
+| method                     | description                                           | return type |
+|----------------------------|-------------------------------------------------------|-------------|
+| isAllowed(string $subject) | returns `true` if the subject is NOT on the deny list | bool        |
+| allow(string $subject)     | Remove this subject from the deny list                | void        |
+| deny(string $subject)      | Add this subject to the deny list                     | void        |
+
+### Abstract Bouncer
+`RoadBunch\Bouncer\AbstractBouncer` implements `RoadBunch\Bouncer\BouncerInterface` and is available to extend if you need to write your own logic to determine if a subject is allowed.
+
+| method                  | description                                             | return type |
+|-------------------------|---------------------------------------------------------|-------------|
+| has(string $subject)    | returns `true` if a subject is held in the subject pool | bool        |
+| add(string $subject)    | Add this subject to the pool                            | void        |
+| remove(string $subject) | Remove this subject from the pool                       | void        |
 
 ## License
 &copy; Dan McAdams | The content of this library is released under the **MIT License**

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 [![Build Status](https://scrutinizer-ci.com/g/The-Road-Bunch/bouncer/badges/build.png?b=main)](https://scrutinizer-ci.com/g/The-Road-Bunch/bouncer/build-status/main)
 
 _What is Bouncer?_  
-Bouncer is an easy-to-use allow/deny list interface. (currently only handles strings)
+
+Bouncer is an easy-to-use allow/deny list interface.
 
 _Why the name Bouncer?_  
-In the real-world, a bouncer holds the list of who is allowed entry and who is not.
 
-AllowBouncer: At an exclusive club, the bouncer has a list and if you're not on it, you can't come in.  
-DenyBouncer: The local bar allows almost everyone in, the bouncer has a list of trouble-makers to stop at the door.
+In the real-world, a bouncer holds the list of who is allowed entry and who is not.
+* AllowBouncer: At an exclusive club, the bouncer has a list and if you're not on it, you can't come in.  
+* DenyBouncer: The local bar allows almost everyone in, the bouncer has a list of trouble-makers to stop at the door.
 
 ### Contents
 1. [Installation](#install)
@@ -129,14 +130,6 @@ $mailer->send('someotheraddress@example.com', 'Welcome!'); // sends mail
 
 ### Bouncers
 All bouncers implement `RoadBunch\Bouncer\BouncerInterface`
-
-`RoadBunch\Bouncer\BouncerInterface`
-
-| method                     | description                                            | return type |
-|----------------------------|--------------------------------------------------------|-------------|
-| isAllowed(string $subject) | Is this string on the allow list/not on the deny list? | bool        |
-| allow(string $subject)     | Add this string to the allow list                      | void        |
-| deny(string $subject)      | Add this string to the deny list                       | void        |
 
 `RoadBunch\Bouncer\AllowBouncer`
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "theroadbunch/bouncer",
-    "description": "",
+    "description": "Bouncer is an easy-to-use allow/deny list interface.",
     "type": "library",
     "autoload": {
         "psr-4": {

--- a/doc/release.md
+++ b/doc/release.md
@@ -1,6 +1,0 @@
-# theroadbunch/bouncer
-
-## v1.0.0
-JAN 22, 2019 - 12:45 CST
-### Notes
-- initial release

--- a/src/Bouncer/AbstractBouncer.php
+++ b/src/Bouncer/AbstractBouncer.php
@@ -19,35 +19,51 @@ namespace RoadBunch\Bouncer;
  */
 abstract class AbstractBouncer implements BouncerInterface
 {
-    /** @var string[] $items */
-    private array $items = [];
+    /** @var string[] $subjectPool */
+    private array $subjectPool = [];
 
-    /** @param string[] $items */
-    public function __construct(array $items = [])
+    /**
+     * Provide an array of strings or a single string value.
+     * If a single string is provided, values will be extracted with the delimiter ';'
+     *
+     * @param string|string[] $subjects
+     */
+    public function __construct(array|string $subjects = [])
     {
-        foreach ($items as $subject) {
-            $this->add($subject);
+        if (is_string($subjects)) {
+            $subjects = $this->subjectsFromString($subjects);
         }
+        array_walk($subjects, [$this, 'add']);
     }
 
     public function has(string $subject): bool
     {
-        return in_array($subject, $this->items);
+        return in_array($subject, $this->subjectPool);
     }
 
     public function add(string $subject): void
     {
         if (!$this->has($subject)) {
-            $this->items[] = $subject;
+            $this->subjectPool[] = $subject;
         }
     }
 
     public function remove(string $subject): void
     {
-        $key = array_search($subject, $this->items);
+        $key = array_search($subject, $this->subjectPool);
 
         if ($key !== false) {
-            unset($this->items[$key]);
+            unset($this->subjectPool[$key]);
         }
+    }
+
+    private function subjectsFromString(string $subjects): array
+    {
+        return array_filter(
+            explode(';', $subjects),
+            function ($subject) {
+                return !empty(trim($subject));
+            }
+        );
     }
 }

--- a/src/Bouncer/AllowBouncer.php
+++ b/src/Bouncer/AllowBouncer.php
@@ -13,11 +13,11 @@ namespace RoadBunch\Bouncer;
 
 
 /**
- * Class AllowList
+ * Class AllowBouncer
  *
  * @author Dan McAdams <dan.mcadams@gmail.com>
  */
-class AllowList extends AbstractBouncer
+class AllowBouncer extends AbstractBouncer
 {
     public function isAllowed(string $subject): bool
     {

--- a/src/Bouncer/Bouncer.php
+++ b/src/Bouncer/Bouncer.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+/**
+ * This file is part of the theroadbunch/bouncer package.
+ *
+ * (c) Dan McAdams <danmcadams@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace RoadBunch\Bouncer;
+
+
+/**
+ * Class Bouncer
+ *
+ * @author Dan McAdams <dan.mcadams@gmail.com>
+ */
+class Bouncer
+{
+    public static function allow(array|string $subjects = []):  BouncerInterface
+    {
+        return new AllowBouncer($subjects);
+    }
+
+    public static function deny(array|string $subjects = []): BouncerInterface
+    {
+        return new DenyBouncer($subjects);
+    }
+}

--- a/src/Bouncer/BouncerFactory.php
+++ b/src/Bouncer/BouncerFactory.php
@@ -12,37 +12,24 @@ declare(strict_types=1);
 namespace RoadBunch\Bouncer;
 
 
+use JetBrains\PhpStorm\Deprecated;
+
 /**
  * Class BouncerFactory
  *
  * @author Dan McAdams <dan.mcadams@gmail.com>
  */
+#[Deprecated(
+    reason: 'Documentation will be removed in v2.4. Use Bouncer::allow or Bouncer::deny instead',
+    replacement: "Use Bouncer::allow or Bouncer::deny instead"
+)]
 class BouncerFactory
 {
     public static function create(Rule $rule, array|string $subjects = []): BouncerInterface
     {
-        if (is_string($subjects)) {
-            $trimmed = [];
-            foreach (explode(';', $subjects) as $subject) {
-                if (!empty($subject)) {
-                    $trimmed[] = trim($subject);
-                }
-            }
-            $subjects = $trimmed;
-        }
         return match ($rule) {
-            Rule::ALLOW => new AllowList($subjects),
-            Rule::DENY => new DenyList($subjects),
+            Rule::ALLOW => new AllowBouncer($subjects),
+            Rule::DENY => new DenyBouncer($subjects),
         };
-    }
-
-    public static function createAllow(array|string $subjects = []): BouncerInterface
-    {
-        return self::create(Rule::ALLOW, $subjects);
-    }
-
-    public static function createDeny(array|string $subjects = []): BouncerInterface
-    {
-        return self::create(Rule::DENY, $subjects);
     }
 }

--- a/src/Bouncer/BouncerFactory.php
+++ b/src/Bouncer/BouncerFactory.php
@@ -19,11 +19,30 @@ namespace RoadBunch\Bouncer;
  */
 class BouncerFactory
 {
-    public static function create(Rule $rule, array $subjects = []): BouncerInterface
+    public static function create(Rule $rule, array|string $subjects = []): BouncerInterface
     {
+        if (is_string($subjects)) {
+            $trimmed = [];
+            foreach (explode(';', $subjects) as $subject) {
+                if (!empty($subject)) {
+                    $trimmed[] = trim($subject);
+                }
+            }
+            $subjects = $trimmed;
+        }
         return match ($rule) {
             Rule::ALLOW => new AllowList($subjects),
             Rule::DENY => new DenyList($subjects),
         };
+    }
+
+    public static function createAllow(array|string $subjects = []): BouncerInterface
+    {
+        return self::create(Rule::ALLOW, $subjects);
+    }
+
+    public static function createDeny(array|string $subjects = []): BouncerInterface
+    {
+        return self::create(Rule::DENY, $subjects);
     }
 }

--- a/src/Bouncer/DenyBouncer.php
+++ b/src/Bouncer/DenyBouncer.php
@@ -13,11 +13,11 @@ namespace RoadBunch\Bouncer;
 
 
 /**
- * Class DenyList
+ * Class DenyBouncer
  *
  * @author Dan McAdams <dan.mcadams@gmail.com>
  */
-class DenyList extends AbstractBouncer
+class DenyBouncer extends AbstractBouncer
 {
     public function isAllowed(string $subject): bool
     {

--- a/tests/Bouncer/AbstractBouncerTest.php
+++ b/tests/Bouncer/AbstractBouncerTest.php
@@ -16,6 +16,7 @@ use RoadBunch\Bouncer\AbstractBouncer;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\CoversClass;
+use RoadBunch\Bouncer\BouncerInterface;
 
 /**
  * Class AbstractBouncerTest
@@ -26,18 +27,46 @@ use PHPUnit\Framework\Attributes\CoversClass;
 final class AbstractBouncerTest extends TestCase
 {
     #[Test]
-    public function hasMethodValueFound(): void
+    public function createBouncer(): void
     {
-        $subject = 'a string';
-        $abstractBouncer = $this->createMockBouncer([$subject]);
+        $this->assertInstanceOf(BouncerInterface::class, $this->makeBouncer());
+    }
+
+    #[Test]
+    public function testCreateBouncerWithArray(): void
+    {
+        $subject = ' a string with ; in it';
+        $abstractBouncer = $this->makeBouncer([$subject]);
 
         $this->assertTrue($abstractBouncer->has($subject));
     }
 
     #[Test]
+    public function createBouncerWithString(): void
+    {
+        $subject = ' a string ';
+        $abstractBouncer = $this->makeBouncer($subject);
+
+        $this->assertTrue($abstractBouncer->has($subject));
+    }
+
+    #[Test]
+    public function testCreateWithSemiColonSeparatedString(): void {
+        $subjects = 'subject one ; subject_two ; subject_three; ';
+        $abstractBouncer = $this->makeBouncer($subjects);
+
+        $this->assertTrue($abstractBouncer->has('subject one '));
+        $this->assertTrue($abstractBouncer->has(' subject_two '));
+        $this->assertTrue($abstractBouncer->has(' subject_three'));
+
+        // empty value at end of the ';' separated string should be dropped
+        $this->assertFalse($abstractBouncer->has(' '));
+    }
+
+    #[Test]
     public function hasMethodValueNotFound(): void
     {
-        $abstractBouncer = $this->createMockBouncer();
+        $abstractBouncer = $this->makeBouncer();
         $subject = 'a string';
 
         $this->assertFalse($abstractBouncer->has($subject));
@@ -46,7 +75,7 @@ final class AbstractBouncerTest extends TestCase
     #[Test]
     public function addValue(): void
     {
-        $abstractBouncer = $this->createMockBouncer();
+        $abstractBouncer = $this->makeBouncer();
         $subject = 'a string';
 
         $abstractBouncer->add($subject);
@@ -57,13 +86,13 @@ final class AbstractBouncerTest extends TestCase
     public function removeValue(): void
     {
         $subject = 'a string';
-        $abstractBouncer = $this->createMockBouncer([$subject]);
+        $abstractBouncer = $this->makeBouncer([$subject]);
 
         $abstractBouncer->remove($subject);
         $this->assertFalse($abstractBouncer->has($subject));
     }
 
-    private function createMockBouncer(array $values = []): AbstractBouncer
+    private function makeBouncer(array|string $values = []): AbstractBouncer
     {
         return $this->getMockForAbstractClass(AbstractBouncer::class, arguments: [$values]);
     }

--- a/tests/Bouncer/AbstractBouncerTest.php
+++ b/tests/Bouncer/AbstractBouncerTest.php
@@ -33,7 +33,7 @@ final class AbstractBouncerTest extends TestCase
     }
 
     #[Test]
-    public function testCreateBouncerWithArray(): void
+    public function createBouncerWithArray(): void
     {
         $subject = ' a string with ; in it';
         $abstractBouncer = $this->makeBouncer([$subject]);
@@ -51,7 +51,7 @@ final class AbstractBouncerTest extends TestCase
     }
 
     #[Test]
-    public function testCreateWithSemiColonSeparatedString(): void {
+    public function createWithSemiColonSeparatedString(): void {
         $subjects = 'subject one ; subject_two ; subject_three; ';
         $abstractBouncer = $this->makeBouncer($subjects);
 

--- a/tests/Bouncer/AllowBouncerTest.php
+++ b/tests/Bouncer/AllowBouncerTest.php
@@ -12,27 +12,27 @@ declare(strict_types=1);
 namespace RoadBunch\Tests\Bouncer;
 
 
-use RoadBunch\Bouncer\AllowList;
+use RoadBunch\Bouncer\AllowBouncer;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
- * Class AllowListTest
+ * Class AllowBouncerTest
  *
  * @author Dan McAdams <dan.mcadams@gmail.com>
  */
-#[CoversClass(AllowList::class)]
-final class AllowListTest extends TestCase
+#[CoversClass(AllowBouncer::class)]
+final class AllowBouncerTest extends TestCase
 {
     #[Test]
     public function createAllowList()
     {
         $domain = 'allowed';
-        $allowList = new AllowList([$domain]);
+        $bouncer = new AllowBouncer([$domain]);
 
-        $this->assertTrue($allowList->isAllowed($domain));
+        $this->assertTrue($bouncer->isAllowed($domain));
     }
 
     #[Test]
@@ -40,33 +40,33 @@ final class AllowListTest extends TestCase
     public function denyRemovesStringFromBlockList(): void
     {
         $domain = 'allowed';
-        $allowList = new AllowList([$domain]);
+        $bouncer = new AllowBouncer([$domain]);
 
-        $this->assertTrue($allowList->isAllowed($domain));
+        $this->assertTrue($bouncer->isAllowed($domain));
 
-        $allowList->deny($domain);
-        $this->assertFalse($allowList->isAllowed($domain));
+        $bouncer->deny($domain);
+        $this->assertFalse($bouncer->isAllowed($domain));
     }
 
     #[Test]
     public function allowAddsStringToBlockList(): void
     {
         $domain = 'allowed';
-        $allowList = new AllowList();
+        $bouncer = new AllowBouncer();
 
-        $this->assertFalse($allowList->isAllowed($domain));
+        $this->assertFalse($bouncer->isAllowed($domain));
 
-        $allowList->allow($domain);
-        $this->assertTrue($allowList->isAllowed($domain));
+        $bouncer->allow($domain);
+        $this->assertTrue($bouncer->isAllowed($domain));
     }
 
     #[Test]
     public function withDuplicateString(): void
     {
-        $allowList = new AllowList(['d', 'd']);
-        $this->assertTrue($allowList->isAllowed('d'));
+        $bouncer = new AllowBouncer(['d', 'd']);
+        $this->assertTrue($bouncer->isAllowed('d'));
 
-        $allowList->deny('d');
-        $this->assertFalse($allowList->isAllowed('d'));
+        $bouncer->deny('d');
+        $this->assertFalse($bouncer->isAllowed('d'));
     }
 }

--- a/tests/Bouncer/BouncerFactoryTest.php
+++ b/tests/Bouncer/BouncerFactoryTest.php
@@ -18,7 +18,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use RoadBunch\Bouncer\AllowBouncer;
-use RoadBunch\Bouncer\Bouncer;
 use RoadBunch\Bouncer\BouncerFactory;
 use RoadBunch\Bouncer\BouncerInterface;
 use RoadBunch\Bouncer\DenyBouncer;

--- a/tests/Bouncer/BouncerFactoryTest.php
+++ b/tests/Bouncer/BouncerFactoryTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 namespace RoadBunch\Tests\Bouncer;
 
 
-use RoadBunch\Bouncer\Rule;
-use RoadBunch\Bouncer\BouncerFactory;
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RoadBunch\Bouncer\AllowList;
+use RoadBunch\Bouncer\BouncerFactory;
+use RoadBunch\Bouncer\BouncerInterface;
+use RoadBunch\Bouncer\Rule;
 
 /**
  * Class BouncerFactoryTest
@@ -19,20 +22,80 @@ use PHPUnit\Framework\Attributes\Test;
 final class BouncerFactoryTest extends TestCase
 {
     #[Test]
-    public function createWithAllowList(): void
+    #[DataProvider('subjectsProvider')]
+    public function createAllowBouncerFromRule(array|string $subjects): void
     {
-        $subject = 'subject';
-        $bouncer = BouncerFactory::create(Rule::ALLOW, [$subject]);
+        $bouncer = BouncerFactory::create(Rule::ALLOW, $subjects);
+        $this->assertInstanceOf(BouncerInterface::class, $bouncer);
+        $this->assertInstanceOf(AllowList::class, $bouncer);
+    }
 
-        $this->assertTrue($bouncer->isAllowed($subject));
+    public static function subjectsProvider(): array
+    {
+        return [
+            'array' => [
+                ['subject_one', 'subject_two', 'subject_three'],
+            ],
+            'single string' => [
+                'subject_one',
+            ],
+            '; separated list' => [
+                'subject_one;subject_two;subject_three',
+            ],
+            '; separated list with spaces' => [
+                'subject_one ; subject_two ; subject_three',
+            ],
+        ];
     }
 
     #[Test]
-    public function createWithDenyList(): void
+    public function createAllowBouncer(): void
     {
         $subject = 'subject';
-        $bouncer = BouncerFactory::create(Rule::DENY, [$subject]);
+        $bouncer = BouncerFactory::createAllow([$subject]);
+
+        $this->assertTrue($bouncer->isAllowed($subject));
+        $this->assertFalse($bouncer->isAllowed(uniqid()));
+    }
+
+    #[Test]
+    public function createDenyBouncer(): void
+    {
+        $subject = 'subject';
+        $bouncer = BouncerFactory::createDeny([$subject]);
 
         $this->assertFalse($bouncer->isAllowed($subject));
+        $this->assertTrue($bouncer->isAllowed(uniqid()));
+    }
+
+    #[Test]
+    public function createAllowBouncerFromString(): void
+    {
+        $subjects = 'subject_one;subject_two;subject_three';
+        $bouncer = BouncerFactory::createAllow($subjects);
+
+        $this->assertTrue($bouncer->isAllowed('subject_one'));
+        $this->assertTrue($bouncer->isAllowed('subject_two'));
+        $this->assertTrue($bouncer->isAllowed('subject_three'));
+        $this->assertFalse($bouncer->isAllowed('subject_four'));
+    }
+
+    #[Test]
+    public function createDenyBouncerFromString(): void
+    {
+        $subjects = 'subject_one;subject_two;subject_three';
+        $bouncer = BouncerFactory::createDeny($subjects);
+
+        $this->assertFalse($bouncer->isAllowed('subject_one'));
+        $this->assertFalse($bouncer->isAllowed('subject_two'));
+        $this->assertFalse($bouncer->isAllowed('subject_three'));
+        $this->assertTrue($bouncer->isAllowed('subject_four'));
+    }
+
+    #[Test]
+    public function testCreateFromListTrimsSpaces(): void
+    {
+        $subjects = 'subject_one ; subject_two; subject_three ; ';
+        $this->markTestSkipped('');
     }
 }

--- a/tests/Bouncer/BouncerFactoryTest.php
+++ b/tests/Bouncer/BouncerFactoryTest.php
@@ -1,16 +1,27 @@
 <?php
 declare(strict_types=1);
+/**
+ * This file is part of the theroadbunch/bouncer package.
+ *
+ * (c) Dan McAdams <danmcadams@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace RoadBunch\Tests\Bouncer;
 
 
+use JetBrains\PhpStorm\Deprecated;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use RoadBunch\Bouncer\AllowList;
+use RoadBunch\Bouncer\AllowBouncer;
+use RoadBunch\Bouncer\Bouncer;
 use RoadBunch\Bouncer\BouncerFactory;
 use RoadBunch\Bouncer\BouncerInterface;
+use RoadBunch\Bouncer\DenyBouncer;
 use RoadBunch\Bouncer\Rule;
 
 /**
@@ -18,6 +29,10 @@ use RoadBunch\Bouncer\Rule;
  *
  * @author Dan McAdams <dan.mcadams@gmail.com>
  */
+#[Deprecated(
+    reason: 'Will be removed in v2.4',
+    replacement: "Use Bouncer::allow or Bouncer::deny instead"
+)]
 #[CoversClass(BouncerFactory::class)]
 final class BouncerFactoryTest extends TestCase
 {
@@ -27,7 +42,16 @@ final class BouncerFactoryTest extends TestCase
     {
         $bouncer = BouncerFactory::create(Rule::ALLOW, $subjects);
         $this->assertInstanceOf(BouncerInterface::class, $bouncer);
-        $this->assertInstanceOf(AllowList::class, $bouncer);
+        $this->assertInstanceOf(AllowBouncer::class, $bouncer);
+    }
+
+    #[Test]
+    #[DataProvider('subjectsProvider')]
+    public function createDenyBouncerFromRule(array|string $subjects): void
+    {
+        $bouncer = BouncerFactory::create(Rule::DENY, $subjects);
+        $this->assertInstanceOf(BouncerInterface::class, $bouncer);
+        $this->assertInstanceOf(DenyBouncer::class, $bouncer);
     }
 
     public static function subjectsProvider(): array
@@ -46,56 +70,5 @@ final class BouncerFactoryTest extends TestCase
                 'subject_one ; subject_two ; subject_three',
             ],
         ];
-    }
-
-    #[Test]
-    public function createAllowBouncer(): void
-    {
-        $subject = 'subject';
-        $bouncer = BouncerFactory::createAllow([$subject]);
-
-        $this->assertTrue($bouncer->isAllowed($subject));
-        $this->assertFalse($bouncer->isAllowed(uniqid()));
-    }
-
-    #[Test]
-    public function createDenyBouncer(): void
-    {
-        $subject = 'subject';
-        $bouncer = BouncerFactory::createDeny([$subject]);
-
-        $this->assertFalse($bouncer->isAllowed($subject));
-        $this->assertTrue($bouncer->isAllowed(uniqid()));
-    }
-
-    #[Test]
-    public function createAllowBouncerFromString(): void
-    {
-        $subjects = 'subject_one;subject_two;subject_three';
-        $bouncer = BouncerFactory::createAllow($subjects);
-
-        $this->assertTrue($bouncer->isAllowed('subject_one'));
-        $this->assertTrue($bouncer->isAllowed('subject_two'));
-        $this->assertTrue($bouncer->isAllowed('subject_three'));
-        $this->assertFalse($bouncer->isAllowed('subject_four'));
-    }
-
-    #[Test]
-    public function createDenyBouncerFromString(): void
-    {
-        $subjects = 'subject_one;subject_two;subject_three';
-        $bouncer = BouncerFactory::createDeny($subjects);
-
-        $this->assertFalse($bouncer->isAllowed('subject_one'));
-        $this->assertFalse($bouncer->isAllowed('subject_two'));
-        $this->assertFalse($bouncer->isAllowed('subject_three'));
-        $this->assertTrue($bouncer->isAllowed('subject_four'));
-    }
-
-    #[Test]
-    public function testCreateFromListTrimsSpaces(): void
-    {
-        $subjects = 'subject_one ; subject_two; subject_three ; ';
-        $this->markTestSkipped('');
     }
 }

--- a/tests/Bouncer/BouncerTest.php
+++ b/tests/Bouncer/BouncerTest.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+/**
+ * This file is part of the theroadbunch/bouncer package.
+ *
+ * (c) Dan McAdams <danmcadams@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace RoadBunch\Tests\Bouncer;
+
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RoadBunch\Bouncer\AllowBouncer;
+use RoadBunch\Bouncer\Bouncer;
+use RoadBunch\Bouncer\BouncerInterface;
+use RoadBunch\Bouncer\DenyBouncer;
+
+/**
+ * Class BouncerTest
+ *
+ * @author Dan McAdams <dan.mcadams@gmail.com>
+ */
+#[CoversClass(Bouncer::class)]
+final class BouncerTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('subjectsProvider')]
+    public function createAllowBouncer(array|string $subjects): void
+    {
+        $bouncer = Bouncer::allow($subjects);
+        $this->assertInstanceOf(BouncerInterface::class, $bouncer);
+        $this->assertInstanceOf(AllowBouncer::class, $bouncer);
+
+        if (is_string($subjects)) {
+            $subjects = explode(';', $subjects);
+        }
+        foreach ($subjects as $subject) {
+            $this->assertTrue($bouncer->isAllowed($subject));
+        }
+        $this->assertFalse($bouncer->isAllowed(uniqid())); // random string
+    }
+
+    #[Test]
+    #[DataProvider('subjectsProvider')]
+    public function createDenyBouncer(array|string $subjects): void
+    {
+        $bouncer = Bouncer::deny($subjects);
+        $this->assertInstanceOf(BouncerInterface::class, $bouncer);
+        $this->assertInstanceOf(DenyBouncer::class, $bouncer);
+
+        if (is_string($subjects)) {
+            $subjects = explode(';', $subjects);
+        }
+        foreach ($subjects as $subject) {
+            $this->assertFalse($bouncer->isAllowed($subject));
+        }
+        $this->assertTrue($bouncer->isAllowed(uniqid())); // random string
+    }
+
+    public static function subjectsProvider(): array
+    {
+        return [
+            'array' => [
+                ['subject_one', 'subject_two', 'subject_three'],
+            ],
+            'single string' => [
+                'subject_one',
+            ],
+            '; separated list' => [
+                'subject_one;subject_two;subject_three',
+            ],
+            '; separated list with spaces' => [
+                'subject_one ; subject_two ; subject_three',
+            ],
+        ];
+    }
+}

--- a/tests/Bouncer/DenyBouncerTest.php
+++ b/tests/Bouncer/DenyBouncerTest.php
@@ -12,59 +12,59 @@ declare(strict_types=1);
 namespace RoadBunch\Tests\Bouncer;
 
 
-use RoadBunch\Bouncer\DenyList;
+use RoadBunch\Bouncer\DenyBouncer;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
- * Class DenyListTest
+ * Class DenyBouncerTest
  *
  * @author Dan McAdams <dan.mcadams@gmail.com>
  */
-#[CoversClass(DenyList::class)]
-final class DenyListTest extends TestCase
+#[CoversClass(DenyBouncer::class)]
+final class DenyBouncerTest extends TestCase
 {
     #[Test]
     public function createDenyList()
     {
         $domain = 'denied';
-        $blockList = new DenyList([$domain]);
+        $bouncer = new DenyBouncer([$domain]);
 
-        $this->assertFalse($blockList->isAllowed($domain));
+        $this->assertFalse($bouncer->isAllowed($domain));
     }
 
     #[Test]
     public function allowRemovesStringFromDenyList(): void
     {
         $domain = 'denied';
-        $blockList = new DenyList([$domain]);
+        $bouncer = new DenyBouncer([$domain]);
 
-        $this->assertFalse($blockList->isAllowed($domain));
+        $this->assertFalse($bouncer->isAllowed($domain));
 
-        $blockList->allow($domain);
-        $this->assertTrue($blockList->isAllowed($domain));
+        $bouncer->allow($domain);
+        $this->assertTrue($bouncer->isAllowed($domain));
     }
 
     #[Test]
     public function denyAddsStringToDenyList(): void
     {
         $domain = 'denied';
-        $blockList = new DenyList();
+        $bouncer = new DenyBouncer();
 
-        $this->assertTrue($blockList->isAllowed($domain));
+        $this->assertTrue($bouncer->isAllowed($domain));
 
-        $blockList->deny($domain);
-        $this->assertFalse($blockList->isAllowed($domain));
+        $bouncer->deny($domain);
+        $this->assertFalse($bouncer->isAllowed($domain));
     }
 
     #[Test]
     public function withDuplicateString(): void
     {
-        $allowList = new DenyList(['d', 'd']);
-        $this->assertFalse($allowList->isAllowed('d'));
+        $bouncer = new DenyBouncer(['d', 'd']);
+        $this->assertFalse($bouncer->isAllowed('d'));
 
-        $allowList->allow('d');
-        $this->assertTrue($allowList->isAllowed('d'));
+        $bouncer->allow('d');
+        $this->assertTrue($bouncer->isAllowed('d'));
     }
 }


### PR DESCRIPTION
* Create new factory `Bouncer` use this instead of the old `BouncerFactory`
  * `Bouncer::allow(array|string $subjects = [])` will create an AllowBouncer
  * `Bouncer::deny(array|string $subjects = [])` will create a DenyBouncer
* Bouncers can now be created by passing a string separated by semi-colons
  * example: `Bouncer::allow('subject_one;subject_two;subject_three')`